### PR TITLE
Fase 2: eliminar N+1 queries y reducir queries por request

### DIFF
--- a/app/main/helpers.py
+++ b/app/main/helpers.py
@@ -9,6 +9,7 @@ from decimal import Decimal, InvalidOperation
 
 from flask import current_app, flash, g, redirect, url_for, session
 from flask_login import current_user
+from sqlalchemy.orm import joinedload
 from PIL import Image
 from io import BytesIO
 
@@ -261,6 +262,7 @@ def store_choices(workshop):
 def bicycle_choices(workshop):
     bicycles = (
         Bicycle.query.filter_by(workshop_id=workshop.id)
+        .options(joinedload(Bicycle.client))
         .order_by(Bicycle.id.desc())
         .all()
     )

--- a/app/services/audit_service.py
+++ b/app/services/audit_service.py
@@ -1,5 +1,7 @@
 from flask import request
 from flask_login import current_user
+from sqlalchemy.orm import joinedload
+
 from ..extensions import db
 from ..models import AuditLog
 
@@ -36,6 +38,7 @@ class AuditService:
         update_types = update_entity_types or [entity_type]
         created_log = (
             AuditLog.query.filter_by(entity_type=entity_type, entity_id=entity_id, action="create")
+            .options(joinedload(AuditLog.user))
             .order_by(AuditLog.created_at.asc())
             .first()
         )
@@ -45,6 +48,7 @@ class AuditService:
                 AuditLog.entity_id == entity_id,
                 AuditLog.action == "update",
             )
+            .options(joinedload(AuditLog.user))
             .order_by(AuditLog.created_at.desc())
             .first()
         )


### PR DESCRIPTION
- Agregar joinedload en bicycle_choices() para cargar clientes en 1 query
- Agregar joinedload en jobs_detail() para bicycle, client, items y parts
- Agregar joinedload en get_audit_info() para cargar user en ambas queries
- Consolidar 4 queries de revenue en 2 con CASE WHEN en dashboard
- Eliminar query redundante de ready_for_delivery (usar status_counts)
- Cachear stores en g.workshop_stores y reusar en inject_theme()