### PR TITLE
release: deploy automatico via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,91 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          SECRET_KEY: test-secret
+        run: pytest -q
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: ${{ secrets.VPS_PORT }}
+          script_stop: true
+          command_timeout: 10m
+          script: |
+            cd /opt/apps/biciservice.cc
+            bash scripts/deploy.sh
+
+      - name: Notify Success
+        if: success()
+        uses: dawidd6/action-send-mail@v3
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          server_address: ${{ secrets.SMTP_HOST }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USER }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "[biciservice] Deploy OK"
+          to: ${{ secrets.ADMIN_NOTIFICATION_EMAIL }}
+          from: ${{ secrets.MAIL_FROM }}
+          body: |
+            Deploy completado exitosamente.
+
+            Commit: ${{ env.COMMIT_SHA }}
+            Branch: main
+            Disparado por: ${{ env.ACTOR }}
+            Workflow: ${{ env.RUN_URL }}
+
+      - name: Notify Failure
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          server_address: ${{ secrets.SMTP_HOST }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USER }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "[biciservice] Deploy FALLO"
+          to: ${{ secrets.ADMIN_NOTIFICATION_EMAIL }}
+          from: ${{ secrets.MAIL_FROM }}
+          body: |
+            Deploy FALLO. Se intento rollback automatico.
+
+            Commit: ${{ env.COMMIT_SHA }}
+            Revisar logs: ${{ env.RUN_URL }}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ DB_SERVICE ?= db
 	build up up-build up-full down restart docker-ps logs \
 	docker-db-upgrade docker-db-migrate docker-db-downgrade docker-test \
 	shell db-shell landing-dev email-test docker-email-test \
-	prod-up prod-down prod-logs prod-db-upgrade prod-shell prod-email-test
+	prod-up prod-down prod-logs prod-db-upgrade prod-shell prod-email-test \
+	prod-backup-db prod-deploy
 
 help: ## Mostrar comandos disponibles
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUso:\n  make <objetivo>\n\nObjetivos:\n"} /^[a-zA-Z0-9_.-]+:.*##/ {printf "  %-22s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -121,3 +122,9 @@ prod-shell: ## Abrir shell en contenedor web produccion
 
 prod-email-test: ## Enviar correo de prueba en produccion (pide email)
 	$(PROD_COMPOSE) exec web $(FLASK) send-test-email
+
+prod-backup-db: ## Backup de base de datos en produccion
+	$(PROD_COMPOSE) exec -T db pg_dump -U postgres biciservice_cc | gzip > /opt/apps/backups/manual/db_$$(date +%Y%m%d_%H%M%S).sql.gz
+
+prod-deploy: ## Ejecutar deploy manual en produccion
+	bash scripts/deploy.sh

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,7 +60,11 @@ def create_app(config_class=Config):
 
     @app.get("/health")
     def health_check():
-        return "ok", 200
+        try:
+            db.session.execute(db.text("SELECT 1"))
+            return {"status": "ok", "db": "connected"}, 200
+        except Exception:
+            return {"status": "error", "db": "disconnected"}, 503
 
     @app.get("/manifest.webmanifest")
     def manifest_file():

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+APP_DIR="/opt/apps/biciservice.cc"
+BACKUP_DIR="/opt/apps/backups/manual"
+COMPOSE_FILE="docker-compose.prod.yml"
+COMPOSE="docker compose -f ${COMPOSE_FILE}"
+DB_SERVICE="db"
+WEB_SERVICE="web"
+DB_NAME="biciservice_cc"
+DB_USER="postgres"
+MAX_BACKUPS=10
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+# ─── State tracking ──────────────────────────────────────────────────────────
+PREV_SHA=""
+BACKUP_DB_FILE=""
+DEPLOY_PHASE="init"
+
+# ─── Rollback function ───────────────────────────────────────────────────────
+rollback() {
+    echo ">>> ROLLBACK INICIADO"
+
+    # Restaurar codigo
+    if [[ -n "${PREV_SHA}" ]]; then
+        echo ">>> Restaurando codigo a ${PREV_SHA}..."
+        cd "${APP_DIR}"
+        git checkout "${PREV_SHA}" 2>/dev/null || git reset --hard "${PREV_SHA}" 2>/dev/null || true
+    fi
+
+    # Restaurar base de datos
+    if [[ -n "${BACKUP_DB_FILE}" && -f "${BACKUP_DB_FILE}" ]]; then
+        echo ">>> Restaurando base de datos desde ${BACKUP_DB_FILE}..."
+        ${COMPOSE} exec -T ${DB_SERVICE} psql -U ${DB_USER} -d ${DB_NAME} \
+            -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;" 2>/dev/null || true
+        gunzip -c "${BACKUP_DB_FILE}" | \
+            ${COMPOSE} exec -T ${DB_SERVICE} psql -U ${DB_USER} ${DB_NAME} 2>/dev/null || true
+    fi
+
+    # Rebuild con codigo anterior
+    if [[ -n "${PREV_SHA}" ]]; then
+        echo ">>> Rebuilding containers con codigo anterior..."
+        ${COMPOSE} up --build -d ${WEB_SERVICE} 2>/dev/null || true
+    fi
+
+    echo ">>> ROLLBACK COMPLETADO (verificacion manual recomendada)"
+}
+
+# ─── Cleanup/Rollback trap ───────────────────────────────────────────────────
+cleanup() {
+    local exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        echo ">>> DEPLOY FALLO en fase: ${DEPLOY_PHASE}"
+        echo ">>> Intentando rollback..."
+        rollback
+    fi
+}
+trap cleanup EXIT
+
+# ─── Phase 1: Preflight ──────────────────────────────────────────────────────
+cd "${APP_DIR}"
+DEPLOY_PHASE="preflight"
+echo ">>> [1/6] Verificaciones previas..."
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "${CURRENT_BRANCH}" != "main" ]]; then
+    echo "ERROR: No estamos en branch main (estamos en ${CURRENT_BRANCH})"
+    exit 1
+fi
+
+docker compose version > /dev/null 2>&1 || { echo "ERROR: docker compose no disponible"; exit 1; }
+
+${COMPOSE} ps --status running ${DB_SERVICE} 2>/dev/null | grep -q "${DB_SERVICE}" || {
+    echo "ERROR: servicio db no esta corriendo"
+    exit 1
+}
+
+echo ">>> Preflight OK"
+
+# ─── Phase 2: Backup ─────────────────────────────────────────────────────────
+DEPLOY_PHASE="backup"
+PREV_SHA=$(git rev-parse HEAD)
+echo ">>> [2/6] Backup (SHA actual: ${PREV_SHA})..."
+
+mkdir -p "${BACKUP_DIR}"
+
+# Database backup
+BACKUP_DB_FILE="${BACKUP_DIR}/db_${TIMESTAMP}.sql.gz"
+echo ">>> pg_dump -> ${BACKUP_DB_FILE}"
+${COMPOSE} exec -T ${DB_SERVICE} pg_dump -U ${DB_USER} ${DB_NAME} | gzip > "${BACKUP_DB_FILE}"
+
+# Validar que el backup no esta vacio
+if [[ ! -s "${BACKUP_DB_FILE}" ]]; then
+    echo "ERROR: Backup de base de datos esta vacio!"
+    exit 1
+fi
+
+# Guardar referencia de codigo
+echo "${PREV_SHA}" > "${BACKUP_DIR}/code_ref_${TIMESTAMP}.txt"
+
+BACKUP_SIZE=$(du -h "${BACKUP_DB_FILE}" | cut -f1)
+echo ">>> Backup OK (DB: ${BACKUP_SIZE})"
+
+# ─── Phase 3: Pull code ──────────────────────────────────────────────────────
+DEPLOY_PHASE="git-pull"
+echo ">>> [3/6] Descargando cambios..."
+
+git fetch origin main
+git reset --hard origin/main
+
+NEW_SHA=$(git rev-parse HEAD)
+echo ">>> ${PREV_SHA:0:7} -> ${NEW_SHA:0:7}"
+
+if [[ "${PREV_SHA}" == "${NEW_SHA}" ]]; then
+    echo ">>> Sin cambios para deployar. Saliendo."
+    exit 0
+fi
+
+# ─── Phase 4: Build ──────────────────────────────────────────────────────────
+DEPLOY_PHASE="build"
+echo ">>> [4/6] Build y restart de contenedores..."
+
+${COMPOSE} up --build -d ${WEB_SERVICE}
+
+# ─── Phase 5: Migrations ─────────────────────────────────────────────────────
+DEPLOY_PHASE="migrate"
+echo ">>> [5/6] Ejecutando migraciones..."
+
+# Esperar a que el contenedor este listo
+sleep 5
+
+${COMPOSE} exec -T ${WEB_SERVICE} flask --app wsgi.py db upgrade
+
+echo ">>> Migraciones OK"
+
+# ─── Phase 6: Health check ───────────────────────────────────────────────────
+DEPLOY_PHASE="healthcheck"
+echo ">>> [6/6] Health check..."
+
+MAX_RETRIES=10
+RETRY_DELAY=3
+
+for i in $(seq 1 ${MAX_RETRIES}); do
+    STATUS=$(${COMPOSE} exec -T ${WEB_SERVICE} python -c \
+        "import urllib.request; print(urllib.request.urlopen('http://localhost:5000/health').status)" 2>/dev/null || echo "failed")
+
+    if [[ "${STATUS}" == "200" ]]; then
+        echo ">>> Health check OK"
+        break
+    fi
+
+    if [[ $i -eq ${MAX_RETRIES} ]]; then
+        echo "ERROR: Health check fallo despues de ${MAX_RETRIES} intentos"
+        exit 1
+    fi
+
+    echo ">>> Intento ${i}/${MAX_RETRIES} fallo, reintentando en ${RETRY_DELAY}s..."
+    sleep ${RETRY_DELAY}
+done
+
+# ─── Cleanup old backups ─────────────────────────────────────────────────────
+echo ">>> Rotando backups (manteniendo ultimos ${MAX_BACKUPS})..."
+ls -t "${BACKUP_DIR}"/db_*.sql.gz 2>/dev/null | tail -n +$((MAX_BACKUPS + 1)) | xargs -r rm -f
+ls -t "${BACKUP_DIR}"/code_ref_*.txt 2>/dev/null | tail -n +$((MAX_BACKUPS + 1)) | xargs -r rm -f
+
+echo ""
+echo "=========================================="
+echo "  DEPLOY EXITOSO"
+echo "  ${PREV_SHA:0:7} -> ${NEW_SHA:0:7}"
+echo "  $(date)"
+echo "=========================================="

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -117,6 +117,15 @@ if [[ "${PREV_SHA}" == "${NEW_SHA}" ]]; then
     exit 0
 fi
 
+# Actualizar ASSET_VERSION en .env con el SHA corto
+SHORT_SHA="${NEW_SHA:0:7}"
+if grep -q "^ASSET_VERSION=" .env 2>/dev/null; then
+    sed -i "s/^ASSET_VERSION=.*/ASSET_VERSION=${SHORT_SHA}/" .env
+else
+    echo "ASSET_VERSION=${SHORT_SHA}" >> .env
+fi
+echo ">>> ASSET_VERSION=${SHORT_SHA}"
+
 # ─── Phase 4: Build ──────────────────────────────────────────────────────────
 DEPLOY_PHASE="build"
 echo ">>> [4/6] Build y restart de contenedores..."


### PR DESCRIPTION
## Summary
- Automated deploy pipeline: on merge to main, GitHub Actions SSHs to VPS and runs `scripts/release.sh`
- Pre-deploy backup: pg_dump gzipped + git SHA reference stored in `/opt/apps/backups/manual/`
- Automatic rollback on failure: restores DB, code, and rebuilds containers
- Auto cache-busting: `ASSET_VERSION` updated with git SHA on every deploy (no more manual tags/releases)
- Enhanced `/health` endpoint verifies DB connectivity
- Email notifications on deploy success/failure
- New Makefile targets: `prod-backup-db`, `prod-deploy`

## PRs included
- #29 feat(deploy): automated deploy pipeline to VPS

## Test plan
- [x] PR checks passed on feature → dev
- [x] PR checks pass on dev → main
- [x] After merge: verify deploy workflow triggers
- [x] Verify backup created on VPS
- [x] Verify `/health` returns `{"status": "ok", "db": "connected"}`
- [x] Verify email notification received